### PR TITLE
feat(ai): ollama coder model-pull + LoadBalancer; scale comfyui to 0

### DIFF
--- a/workloads/ai/comfyui.go
+++ b/workloads/ai/comfyui.go
@@ -42,7 +42,7 @@ func NewComfyUIChart(scope constructs.Construct, id string, namespace string) cd
 		},
 	})
 
-	replicas := float64(1)
+	replicas := float64(0)
 	k8s.NewKubeDeployment(chart, jsii.String("comfyui"), &k8s.KubeDeploymentProps{
 		Metadata: &k8s.ObjectMeta{
 			Name:      jsii.String("comfyui"),

--- a/workloads/ai/ollama.go
+++ b/workloads/ai/ollama.go
@@ -37,12 +37,12 @@ func NewOllamaChart(scope constructs.Construct, id string, namespace string) cdk
 					"nvidia.com/gpu": 1,
 					// memory here is host RAM (cgroup limit), NOT GPU VRAM.
 					// GPU VRAM (16GB) is fully available via nvidia.com/gpu: 1.
-					// Worker4 has 6GB host RAM total; keep limit below that.
-					"memory": "4Gi",
+					// host RAM cgroup limit (worker4 ~15.6Gi); 8Gi headroom for 14b model load.
+					"memory": "8Gi",
 					"cpu":    "4000m",
 				},
 				"requests": map[string]any{
-					"memory": "2Gi",
+					"memory": "4Gi",
 					"cpu":    "1000m",
 				},
 			},
@@ -51,7 +51,7 @@ func NewOllamaChart(scope constructs.Construct, id string, namespace string) cdk
 				"size":    "100Gi",
 			},
 			"service": map[string]any{
-				"type": "ClusterIP",
+				"type": "LoadBalancer",
 				"port": 11434,
 			},
 			"nodeSelector": gpuNodeSelector,
@@ -63,6 +63,13 @@ func NewOllamaChart(scope constructs.Construct, id string, namespace string) cdk
 			"runtimeClassName": "nvidia",
 			"extraEnv": []map[string]any{
 				{"name": "NVIDIA_VISIBLE_DEVICES", "value": "all"},
+			},
+			// Declarative model pull (otwld chart): pulled on boot into the 100Gi
+			// PVC, idempotent, survives pod/PVC recreation.
+			"ollama": map[string]any{
+				"models": map[string]any{
+					"pull": []string{"qwen2.5-coder:14b"},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Enables the local-model code-offload workflow (see `local-ai-setup`) on the homelab GPU, declaratively.

## Changes
**`workloads/ai/ollama.go`** (otwld/ollama-helm @1.57.0)
- **Model pull**: `ollama.models.pull: [qwen2.5-coder:14b]` — pulled on boot into the 100Gi PVC, idempotent, survives pod/PVC recreation (replaces manual `ollama pull`).
- **Reachability**: service `ClusterIP` → `LoadBalancer` → stable `192.168.1.x` LAN IP via Cilium LB-IPAM (low-latency aider access). `ollama.madhan.app` HTTPRoute unchanged.
- **RAM**: host limit `4Gi`→`8Gi` (req `2Gi`→`4Gi`) for 14b load headroom; fixed stale "6GB" comment (worker4 has ~15.6Gi).

**`workloads/ai/comfyui.go`**
- `replicas` `1`→`0` — unused; frees host RAM + a GPU time-slice for ollama.

## Notes
- Go source only; CI (`cdk8s-seal-publish`) synthesizes `app/` and ArgoCD applies.
- `go build ./ai/` passes locally.
- After merge: grab the LB IP with `kubectl -n ollama get svc ollama -o jsonpath='{.status.loadBalancer.ingress[0].ip}'` for `.env` `OLLAMA_API_BASE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)